### PR TITLE
Feature/2 build convenience api

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,74 @@
-# k8s-container-learning-day-2023
-A learning day exercise which transfers the Testcontainer concept to Kubernetes 
+# testclusters-go
+
+A [golang](https://go.dev)-test compatible Kubernetes cluster test framework based on K3s.
+
+This framework sets up and tears down Kubernetes clusters by-the-test. All you need is a [Docker](https://docker.com) environment. 
+
+Currently, the Kubernetes API v1.28.2 is supported.
+
+## Examples
+
+The most minimal example would look like this, which creates a cluster and deletes all containers and networks created during the start-up:
+
+```golang
+package test
+
+import "testing"
+import "github.com/test-cluster/testclusters-go/pkg/cluster"
+
+func TestExample(t *testing.T) {
+	cluster.NewK3dCluster(t)
+	// test ends and the cluster will be deleted automatically
+}
+
+```
+
+Looking up pods from an nginx deployment:
+
+```golang
+//go:embed testdata/simpleNginxDeployment.yaml
+var simpleNginxDeploymentBytes []byte
+
+func TestExample(t *testing.T) {
+
+	// given
+	cluster := NewK3dCluster(t)
+	ctx := context.Background()
+
+	kubectl, err := cluster.CtlKube(t.Name())
+	require.NoError(t, err)
+
+	// when
+	err = kubectl.ApplyWithFile(ctx, simpleNginxDeploymentBytes)
+	c, err := cluster.ClientSet()
+	require.NoError(t, err)
+
+	eventualMsg := ""
+	
+	assert.Eventually(t, func() bool {
+		list, err := c.CoreV1().Pods("default").List(ctx, metav1.ListOptions{
+			LabelSelector: "app=nginx",
+		})
+		if err != nil {
+			eventualMsg = fmt.Sprintf("not pods with labels %s found", "app=nginx")
+			return false
+		}
+		if len(list.Items) < 1 {
+			eventualMsg = fmt.Sprintf("pod list empty for labels %s", "app=nginx")
+			return false
+		}
+
+		if list.Items[0].Status.Phase != v1.PodRunning {
+			eventualMsg = fmt.Sprintf("pod phase not running %s is in %s", list.Items[0].Name, list.Items[0].Status.Phase)
+			return false
+		}
+
+		return true
+	}, 5*time.Second, 1*time.Second)
+
+
+	// then
+	assert.NoError(t, err)
+	assert.Equal(t, "", eventualMsg)
+}
+```

--- a/docs/features.md
+++ b/docs/features.md
@@ -9,7 +9,7 @@
   - :note: do you want to debug containers? It does not have to be containers :note:
 - apply kubernetes resources at cluster start-up time
   - simplify repeated tasks
-- kubectl usage
+- kubectl-like applying of kubernetes YAML resources thanks to the Cloudogu [apply-lib](https://github.com/cloudogu/k8s-apply-lib)
   - do you want to have resources? Because that's how you get resources
 - Enable external access to cluster pods
   - Loadbalancer/ingress testing

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/ppxl/testclusters-go
+module github.com/test-clusters/testclusters-go
 
 go 1.21
 

--- a/pkg/cluster/cluster.go
+++ b/pkg/cluster/cluster.go
@@ -313,21 +313,18 @@ func (c *K3dCluster) CtlKube(fieldManager string) (*YamlApplier, error) {
 }
 
 type PodList struct {
-	t           *testing.T
 	pods        corev1.PodInterface
 	listOptions metav1.ListOptions
 }
 
 func (pl *PodList) Eventually() *PodList {
 	return &PodList{
-		t:           pl.t,
 		pods:        pl.pods,
 		listOptions: pl.listOptions,
 	}
 }
 
 func (pl *PodList) Len(ctx context.Context, expected int) error {
-	pl.t.Helper()
 	list, err := pl.pods.List(ctx, pl.listOptions)
 	if err != nil {
 		return fmt.Errorf("could not list pods for listOptions %s: %w", pl.listOptions.String(), err)
@@ -347,8 +344,6 @@ func (pl *PodList) Raw(ctx context.Context) (*v1.PodList, error) {
 }
 
 func (pl *PodList) StatusPhase(ctx context.Context, expected v1.PodPhase) error {
-	pl.t.Helper()
-
 	list, err := pl.pods.List(ctx, pl.listOptions)
 	if err != nil {
 		return fmt.Errorf("could not list pods for listOptions %s: %s", pl.listOptions.String(), err.Error())
@@ -364,13 +359,11 @@ func (pl *PodList) StatusPhase(ctx context.Context, expected v1.PodPhase) error 
 }
 
 type PodSelector struct {
-	t    *testing.T
 	pods corev1.PodInterface
 }
 
 func (s *PodSelector) ByLabels(labels string) *PodList {
 	return &PodList{
-		t:    s.t,
 		pods: s.pods,
 		listOptions: metav1.ListOptions{
 			LabelSelector: labels,
@@ -385,7 +378,6 @@ type Lookout struct {
 
 func (l *Lookout) Pods(namespace string) *PodSelector {
 	return &PodSelector{
-		t:    l.t,
 		pods: l.c.CoreV1().Pods(namespace),
 	}
 }

--- a/pkg/cluster/cluster.go
+++ b/pkg/cluster/cluster.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"github.com/k3d-io/k3d/v5/pkg/config/v1alpha5"
 	l "github.com/k3d-io/k3d/v5/pkg/logger"
+	corev1 "k8s.io/client-go/kubernetes/typed/core/v1"
 	"k8s.io/client-go/rest"
 	"strconv"
 	"testing"
@@ -319,4 +320,88 @@ func (c *K3dCluster) CtlKube(fieldManager string) (*YamlApplier, error) {
 		return nil, fmt.Errorf("ctlkube call failed: %w", err)
 	}
 	return yamlApplier, nil
+}
+
+type PodList struct {
+	t           *testing.T
+	pods        corev1.PodInterface
+	listOptions metav1.ListOptions
+}
+
+func (pl *PodList) Eventually() *PodList {
+	return &PodList{
+		t:           pl.t,
+		pods:        pl.pods,
+		listOptions: pl.listOptions,
+	}
+}
+
+func (pl *PodList) Len(ctx context.Context, expected int) error {
+	pl.t.Helper()
+	list, err := pl.pods.List(ctx, pl.listOptions)
+	if err != nil {
+		return fmt.Errorf("could not list pods for listOptions %s: %s", pl.listOptions.String(), err.Error())
+	}
+
+	itemsLen := len(list.Items)
+	if itemsLen != expected {
+		return fmt.Errorf("did not find expected number of pods. expected; %d; actual: %d", expected, itemsLen)
+	}
+
+	return nil
+}
+
+func (pl *PodList) StatusPhase(ctx context.Context, expected v1.PodPhase) error {
+	pl.t.Helper()
+	list, err := pl.pods.List(ctx, pl.listOptions)
+	if err != nil {
+		return fmt.Errorf("could not list pods for listOptions %s: %s", pl.listOptions.String(), err.Error())
+	}
+
+	for _, pod := range list.Items {
+		if pod.Status.Phase != expected {
+			return fmt.Errorf("pod %s is not in expected lifecycle-pahase. expected; %s; actual: %s", pod.Name, expected, pod.Status.Phase)
+		}
+	}
+
+	return nil
+}
+
+type PodSelector struct {
+	t    *testing.T
+	pods corev1.PodInterface
+}
+
+func (s *PodSelector) ByLabels(labels string) *PodList {
+	return &PodList{
+		t:    s.t,
+		pods: s.pods,
+		listOptions: metav1.ListOptions{
+			LabelSelector: labels,
+		},
+	}
+}
+
+type Lookout struct {
+	t *testing.T
+	c kubernetes.Interface
+}
+
+func (l *Lookout) Pods(namespace string) *PodSelector {
+	return &PodSelector{
+		t:    l.t,
+		pods: l.c.CoreV1().Pods(namespace),
+	}
+}
+
+func (c *K3dCluster) Lookout(t *testing.T) *Lookout {
+	clientSet, err := c.ClientSet()
+	if err != nil {
+		t.Errorf("could not build clientSet for cluster: %s", err.Error())
+	}
+
+	return &Lookout{
+		t: t,
+		c: clientSet,
+	}
 }

--- a/pkg/cluster/cluster.go
+++ b/pkg/cluster/cluster.go
@@ -19,7 +19,6 @@ import (
 	rbacv1 "k8s.io/api/rbac/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes"
-	corev1 "k8s.io/client-go/kubernetes/typed/core/v1"
 	"k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/clientcmd"
 	"k8s.io/client-go/tools/clientcmd/api"
@@ -310,65 +309,6 @@ func (c *K3dCluster) CtlKube(fieldManager string) (*YamlApplier, error) {
 		return nil, fmt.Errorf("ctlkube call failed: %w", err)
 	}
 	return yamlApplier, nil
-}
-
-type PodList struct {
-	pods        corev1.PodInterface
-	listOptions metav1.ListOptions
-}
-
-func (pl *PodList) Eventually() *PodList {
-	return &PodList{
-		pods:        pl.pods,
-		listOptions: pl.listOptions,
-	}
-}
-
-func (pl *PodList) Len(ctx context.Context, expected int) error {
-	list, err := pl.pods.List(ctx, pl.listOptions)
-	if err != nil {
-		return fmt.Errorf("could not list pods for listOptions %s: %w", pl.listOptions.String(), err)
-	}
-
-	itemsLen := len(list.Items)
-	if itemsLen != expected {
-		return fmt.Errorf("did not find expected number of pods: expected: %d; actual: %d", expected, itemsLen)
-	}
-
-	return nil
-}
-
-// Raw queries the kubernetes API and returns the pod list as plain kubernetes API objects.
-func (pl *PodList) Raw(ctx context.Context) (*v1.PodList, error) {
-	return pl.pods.List(ctx, pl.listOptions)
-}
-
-func (pl *PodList) StatusPhase(ctx context.Context, expected v1.PodPhase) error {
-	list, err := pl.pods.List(ctx, pl.listOptions)
-	if err != nil {
-		return fmt.Errorf("could not list pods for listOptions %s: %s", pl.listOptions.String(), err.Error())
-	}
-
-	for _, pod := range list.Items {
-		if pod.Status.Phase != expected {
-			return fmt.Errorf("pod %s is not in expected lifecycle-pahase. expected; %s; actual: %s", pod.Name, expected, pod.Status.Phase)
-		}
-	}
-
-	return nil
-}
-
-type PodSelector struct {
-	pods corev1.PodInterface
-}
-
-func (s *PodSelector) ByLabels(labels string) *PodList {
-	return &PodList{
-		pods: s.pods,
-		listOptions: metav1.ListOptions{
-			LabelSelector: labels,
-		},
-	}
 }
 
 type Lookout struct {

--- a/pkg/cluster/cluster.go
+++ b/pkg/cluster/cluster.go
@@ -3,10 +3,6 @@ package cluster
 import (
 	"context"
 	"fmt"
-	"github.com/k3d-io/k3d/v5/pkg/config/v1alpha5"
-	l "github.com/k3d-io/k3d/v5/pkg/logger"
-	corev1 "k8s.io/client-go/kubernetes/typed/core/v1"
-	"k8s.io/client-go/rest"
 	"strconv"
 	"testing"
 	"time"
@@ -14,6 +10,8 @@ import (
 	"github.com/k3d-io/k3d/v5/pkg/client"
 	"github.com/k3d-io/k3d/v5/pkg/config"
 	configTypes "github.com/k3d-io/k3d/v5/pkg/config/types"
+	"github.com/k3d-io/k3d/v5/pkg/config/v1alpha5"
+	l "github.com/k3d-io/k3d/v5/pkg/logger"
 	"github.com/k3d-io/k3d/v5/pkg/runtimes"
 	k3dTypes "github.com/k3d-io/k3d/v5/pkg/types"
 	"github.com/phayes/freeport"
@@ -21,10 +19,12 @@ import (
 	rbacv1 "k8s.io/api/rbac/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes"
+	corev1 "k8s.io/client-go/kubernetes/typed/core/v1"
+	"k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/clientcmd"
 	"k8s.io/client-go/tools/clientcmd/api"
 
-	"github.com/ppxl/testclusters-go/pkg/naming"
+	"github.com/test-clusters/testclusters-go/pkg/naming"
 )
 
 const appName = "k8s-containers"
@@ -59,36 +59,26 @@ func NewK3dCluster(t *testing.T) *K3dCluster {
 }
 
 func setupCluster(t *testing.T) *K3dCluster {
-	l.Log().Info("===== =====")
 	l.Log().Info("testcluster-go: Creating cluster during  ")
-	l.Log().Info("===== =====")
 	var err error
 	cluster, err := CreateK3dCluster(context.Background(), "hello-world")
 	if err != nil {
 		t.Errorf("Unexpected error during test setup: %s\n", err)
 	}
-	l.Log().Info("===== =====")
 	l.Log().Info("testcluster-go: Cluster was successfully created")
-	l.Log().Info("===== =====")
 
 	return cluster
 }
 
 func registerTearDown(t *testing.T, cluster *K3dCluster) {
 	t.Cleanup(func() {
-		l.Log().Info("===== =====")
 		l.Log().Info("testcluster-go: Terminating cluster during test tear down")
-		l.Log().Info("===== =====")
 		err := cluster.Terminate(context.Background())
 		if err != nil {
-			l.Log().Info("===== =====")
 			l.Log().Info("testcluster-go: Cluster was termination failed")
-			l.Log().Info("===== =====")
 			t.Errorf("Unexpected error during test tear down: %s\n", err.Error())
 		}
-		l.Log().Info("===== =====")
 		l.Log().Info("testcluster-go: Cluster was successfully terminated")
-		l.Log().Info("===== =====")
 	})
 }
 
@@ -149,7 +139,7 @@ my.company.registry":
 		return nil, fmt.Errorf("failed to transform cluster config: %w", err)
 	}
 
-	println(fmt.Sprintf("===== used cluster config =====\n%#v\n===== =====", clusterConfig))
+	//println(fmt.Sprintf("===== used cluster config =====\n%#v\n===== =====", clusterConfig))
 
 	clusterConfig, err = config.ProcessClusterConfig(*clusterConfig)
 	if err != nil {

--- a/pkg/cluster/cluster.go
+++ b/pkg/cluster/cluster.go
@@ -316,9 +316,16 @@ type Lookout struct {
 	c kubernetes.Interface
 }
 
-func (l *Lookout) Pods(namespace string) *PodSelector {
+func (l *Lookout) Pods(namespace string) *PodListSelector {
+	return &PodListSelector{
+		podClient: l.c.CoreV1().Pods(namespace),
+	}
+}
+
+func (l *Lookout) Pod(namespace, name string) *PodSelector {
 	return &PodSelector{
-		pods: l.c.CoreV1().Pods(namespace),
+		podClient: l.c.CoreV1().Pods(namespace),
+		name:      name,
 	}
 }
 

--- a/pkg/cluster/cluster.go
+++ b/pkg/cluster/cluster.go
@@ -330,19 +330,25 @@ func (pl *PodList) Len(ctx context.Context, expected int) error {
 	pl.t.Helper()
 	list, err := pl.pods.List(ctx, pl.listOptions)
 	if err != nil {
-		return fmt.Errorf("could not list pods for listOptions %s: %s", pl.listOptions.String(), err.Error())
+		return fmt.Errorf("could not list pods for listOptions %s: %w", pl.listOptions.String(), err)
 	}
 
 	itemsLen := len(list.Items)
 	if itemsLen != expected {
-		return fmt.Errorf("did not find expected number of pods. expected; %d; actual: %d", expected, itemsLen)
+		return fmt.Errorf("did not find expected number of pods: expected: %d; actual: %d", expected, itemsLen)
 	}
 
 	return nil
 }
 
+// Raw queries the kubernetes API and returns the pod list as plain kubernetes API objects.
+func (pl *PodList) Raw(ctx context.Context) (*v1.PodList, error) {
+	return pl.pods.List(ctx, pl.listOptions)
+}
+
 func (pl *PodList) StatusPhase(ctx context.Context, expected v1.PodPhase) error {
 	pl.t.Helper()
+
 	list, err := pl.pods.List(ctx, pl.listOptions)
 	if err != nil {
 		return fmt.Errorf("could not list pods for listOptions %s: %s", pl.listOptions.String(), err.Error())

--- a/pkg/cluster/cluster.go
+++ b/pkg/cluster/cluster.go
@@ -324,8 +324,9 @@ func (l *Lookout) Pods(namespace string) *PodListSelector {
 
 func (l *Lookout) Pod(namespace, name string) *PodSelector {
 	return &PodSelector{
-		podClient: l.c.CoreV1().Pods(namespace),
-		name:      name,
+		podClient:   l.c.CoreV1().Pods(namespace),
+		eventClient: l.c.CoreV1().Events(namespace),
+		name:        name,
 	}
 }
 

--- a/pkg/cluster/cluster_test.go
+++ b/pkg/cluster/cluster_test.go
@@ -3,7 +3,11 @@ package cluster
 import (
 	"context"
 	_ "embed"
+	"fmt"
+	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"testing"
+	"time"
 
 	l "github.com/k3d-io/k3d/v5/pkg/logger"
 
@@ -31,10 +35,45 @@ func TestExample(t *testing.T) {
 	l.Log().Info("apply yaml bytes")
 	l.Log().Info("===== =====")
 	err = kubectl.ApplyWithFile(ctx, simpleNginxDeploymentBytes)
+	c, err := cluster.ClientSet()
+	require.NoError(t, err)
+
+	leMsg := "asdf"
+	assert.Eventuallyf(t, func() bool {
+		list, err := c.CoreV1().Pods("default").List(ctx, metav1.ListOptions{
+			LabelSelector: "app=nginx",
+		})
+		if err != nil {
+			leMsg = fmt.Sprintf("not pods with labels %s found", "app=nginx")
+			println("not yet app=nginx seletect")
+			return false
+		}
+		if len(list.Items) < 1 {
+			leMsg = fmt.Sprintf("pod list empty for labels %s", "app=nginx")
+			println("pod list empty app=nginx")
+			return false
+		}
+
+		if list.Items[0].Status.Phase != v1.PodRunning {
+			leMsg = fmt.Sprintf("pod phase not running %s is in %s", list.Items[0].Name, list.Items[0].Status.Phase)
+			println("pod phase not running app=nginx", list.Items[0].Name)
+			return false
+		}
+
+		return true
+	}, 5*time.Second, 1*time.Second, leMsg)
+	assert.Equal(t, "qwer", leMsg)
+
 	l.Log().Info("===== =====")
 	l.Log().Infof("apply yaml bytes with result %v", err)
 	l.Log().Info("===== =====")
 
 	// then
 	assert.NoError(t, err)
+}
+
+var defaultTimeout = 20 * time.Second
+
+func Within(t *testing.T, yourAssert func()) {
+
 }

--- a/pkg/cluster/cluster_test.go
+++ b/pkg/cluster/cluster_test.go
@@ -8,7 +8,6 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	v1 "k8s.io/api/core/v1"
 
 	"github.com/test-clusters/testclusters-go/pkg/cluster"
 )
@@ -30,7 +29,7 @@ func TestIntegration(t *testing.T) {
 	//c, err := cluster.ClientSet()
 	require.NoError(t, err)
 
-	pods := cl.Lookout(t).Pods("default").ByLabels("app=nginx")
+	pods := cl.Lookout(t).Pods("default").ByLabels("app=nginx").ByFieldSelector("status.phase=Running").List()
 	assert.EventuallyWithT(t, func(collectT *assert.CollectT) {
 		err := pods.Len(ctx, 3)
 		if err != nil {

--- a/pkg/cluster/cluster_test.go
+++ b/pkg/cluster/cluster_test.go
@@ -1,42 +1,36 @@
-package cluster
+package cluster_test
 
 import (
 	"context"
 	_ "embed"
-	v1 "k8s.io/api/core/v1"
 	"testing"
 	"time"
 
-	l "github.com/k3d-io/k3d/v5/pkg/logger"
-
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	v1 "k8s.io/api/core/v1"
+
+	"github.com/test-clusters/testclusters-go/pkg/cluster"
 )
 
 //go:embed testdata/simpleNginxDeployment.yaml
 var simpleNginxDeploymentBytes []byte
 
-func TestExample(t *testing.T) {
-
-	cluster := NewK3dCluster(t)
+func TestIntegration(t *testing.T) {
 
 	// given
+	cl := cluster.NewK3dCluster(t)
 	ctx := context.Background()
-	l.Log().Info("===== =====")
-	l.Log().Info("get kubectl")
-	l.Log().Info("===== =====")
-	kubectl, err := cluster.CtlKube(t.Name())
+
+	kubectl, err := cl.CtlKube(t.Name())
 	require.NoError(t, err)
 
 	// when
-	l.Log().Info("===== =====")
-	l.Log().Info("apply yaml bytes")
-	l.Log().Info("===== =====")
 	err = kubectl.ApplyWithFile(ctx, simpleNginxDeploymentBytes)
 	//c, err := cluster.ClientSet()
 	require.NoError(t, err)
 
-	pods := cluster.Lookout(t).Pods("default").ByLabels("app=nginx")
+	pods := cl.Lookout(t).Pods("default").ByLabels("app=nginx")
 	assert.EventuallyWithT(t, func(collectT *assert.CollectT) {
 		err := pods.Len(ctx, 3)
 		if err != nil {
@@ -51,16 +45,6 @@ func TestExample(t *testing.T) {
 		}
 	}, 60*time.Second, 1*time.Second)
 
-	l.Log().Info("===== =====")
-	l.Log().Infof("apply yaml bytes with result %v", err)
-	l.Log().Info("===== =====")
-
 	// then
 	assert.NoError(t, err)
-}
-
-var defaultTimeout = 20 * time.Second
-
-func Within(t *testing.T, yourAssert func()) {
-
 }

--- a/pkg/cluster/cluster_test.go
+++ b/pkg/cluster/cluster_test.go
@@ -3,9 +3,7 @@ package cluster
 import (
 	"context"
 	_ "embed"
-	"fmt"
 	v1 "k8s.io/api/core/v1"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"testing"
 	"time"
 
@@ -35,34 +33,23 @@ func TestExample(t *testing.T) {
 	l.Log().Info("apply yaml bytes")
 	l.Log().Info("===== =====")
 	err = kubectl.ApplyWithFile(ctx, simpleNginxDeploymentBytes)
-	c, err := cluster.ClientSet()
+	//c, err := cluster.ClientSet()
 	require.NoError(t, err)
 
-	leMsg := "asdf"
-	assert.Eventuallyf(t, func() bool {
-		list, err := c.CoreV1().Pods("default").List(ctx, metav1.ListOptions{
-			LabelSelector: "app=nginx",
-		})
+	pods := cluster.Lookout(t).Pods("default").ByLabels("app=nginx")
+	assert.EventuallyWithT(t, func(collectT *assert.CollectT) {
+		err := pods.Len(ctx, 3)
 		if err != nil {
-			leMsg = fmt.Sprintf("not pods with labels %s found", "app=nginx")
-			println("not yet app=nginx seletect")
-			return false
+			collectT.Errorf("%w", err)
 		}
-		if len(list.Items) < 1 {
-			leMsg = fmt.Sprintf("pod list empty for labels %s", "app=nginx")
-			println("pod list empty app=nginx")
-			return false
-		}
+	}, 10*time.Second, 1*time.Second)
 
-		if list.Items[0].Status.Phase != v1.PodRunning {
-			leMsg = fmt.Sprintf("pod phase not running %s is in %s", list.Items[0].Name, list.Items[0].Status.Phase)
-			println("pod phase not running app=nginx", list.Items[0].Name)
-			return false
+	assert.EventuallyWithT(t, func(collectT *assert.CollectT) {
+		err := pods.StatusPhase(ctx, v1.PodRunning)
+		if err != nil {
+			collectT.Errorf("%w", err)
 		}
-
-		return true
-	}, 5*time.Second, 1*time.Second, leMsg)
-	assert.Equal(t, "qwer", leMsg)
+	}, 60*time.Second, 1*time.Second)
 
 	l.Log().Info("===== =====")
 	l.Log().Infof("apply yaml bytes with result %v", err)

--- a/pkg/cluster/cluster_test.go
+++ b/pkg/cluster/cluster_test.go
@@ -37,13 +37,6 @@ func TestIntegration(t *testing.T) {
 		}
 	}, 10*time.Second, 1*time.Second)
 
-	assert.EventuallyWithT(t, func(collectT *assert.CollectT) {
-		err := pods.StatusPhase(ctx, v1.PodRunning)
-		if err != nil {
-			collectT.Errorf("%w", err)
-		}
-	}, 60*time.Second, 1*time.Second)
-
 	// then
 	assert.NoError(t, err)
 }

--- a/pkg/cluster/pod.go
+++ b/pkg/cluster/pod.go
@@ -1,0 +1,18 @@
+package cluster
+
+import (
+	"context"
+
+	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	corev1 "k8s.io/client-go/kubernetes/typed/core/v1"
+)
+
+type PodSelector struct {
+	podClient corev1.PodInterface
+	name      string
+}
+
+func (ps *PodSelector) Raw(ctx context.Context) (*v1.Pod, error) {
+	return ps.podClient.Get(ctx, ps.name, metav1.GetOptions{})
+}

--- a/pkg/cluster/pod.go
+++ b/pkg/cluster/pod.go
@@ -2,6 +2,8 @@ package cluster
 
 import (
 	"context"
+	"fmt"
+	"strings"
 
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -9,10 +11,19 @@ import (
 )
 
 type PodSelector struct {
-	podClient corev1.PodInterface
-	name      string
+	podClient   corev1.PodInterface
+	eventClient corev1.EventInterface
+	name        string
 }
 
 func (ps *PodSelector) Raw(ctx context.Context) (*v1.Pod, error) {
 	return ps.podClient.Get(ctx, ps.name, metav1.GetOptions{})
+}
+
+func (ps *PodSelector) Events(ctx context.Context, fieldSelectors ...string) (*v1.EventList, error) {
+	joinedSelector := strings.Join(append(fieldSelectors, fmt.Sprintf("involvedObject.name=%s", ps.name)), ",")
+	return ps.eventClient.List(ctx, metav1.ListOptions{
+		FieldSelector: joinedSelector,
+		TypeMeta:      metav1.TypeMeta{Kind: "Pod"},
+	})
 }

--- a/pkg/cluster/pod.go
+++ b/pkg/cluster/pod.go
@@ -5,25 +5,41 @@ import (
 	"fmt"
 	"strings"
 
-	v1 "k8s.io/api/core/v1"
+	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	corev1 "k8s.io/client-go/kubernetes/typed/core/v1"
+	typecorev1 "k8s.io/client-go/kubernetes/typed/core/v1"
 )
 
 type PodSelector struct {
-	podClient   corev1.PodInterface
-	eventClient corev1.EventInterface
+	podClient   typecorev1.PodInterface
+	eventClient typecorev1.EventInterface
 	name        string
 }
 
-func (ps *PodSelector) Raw(ctx context.Context) (*v1.Pod, error) {
+func (ps *PodSelector) Raw(ctx context.Context) (*corev1.Pod, error) {
 	return ps.podClient.Get(ctx, ps.name, metav1.GetOptions{})
 }
 
-func (ps *PodSelector) Events(ctx context.Context, fieldSelectors ...string) (*v1.EventList, error) {
+func (ps *PodSelector) Events(ctx context.Context, fieldSelectors ...string) (*corev1.EventList, error) {
 	joinedSelector := strings.Join(append(fieldSelectors, fmt.Sprintf("involvedObject.name=%s", ps.name)), ",")
 	return ps.eventClient.List(ctx, metav1.ListOptions{
 		FieldSelector: joinedSelector,
 		TypeMeta:      metav1.TypeMeta{Kind: "Pod"},
 	})
+}
+
+func (ps *PodSelector) Logs(ctx context.Context) ([]byte, error) {
+	podLogOpts := &corev1.PodLogOptions{}
+	logReq := ps.podClient.GetLogs(ps.name, podLogOpts)
+	result := logReq.Do(ctx)
+	if result.Error() != nil {
+		return []byte{}, result.Error()
+	}
+
+	raw, err := result.Raw()
+	if err != nil {
+		return nil, err
+	}
+
+	return raw, nil
 }

--- a/pkg/cluster/podList.go
+++ b/pkg/cluster/podList.go
@@ -10,12 +10,12 @@ import (
 )
 
 type PodList struct {
-	pods        corev1.PodInterface
+	podClient   corev1.PodInterface
 	listOptions metav1.ListOptions
 }
 
 func (pl *PodList) Len(ctx context.Context, expected int) error {
-	list, err := pl.pods.List(ctx, pl.listOptions)
+	list, err := pl.podClient.List(ctx, pl.listOptions)
 	if err != nil {
 		return fmt.Errorf("could not list pods for listOptions %s: %w", pl.listOptions.String(), err)
 	}
@@ -30,35 +30,35 @@ func (pl *PodList) Len(ctx context.Context, expected int) error {
 
 // Raw queries the kubernetes API and returns the pod list as plain kubernetes API objects.
 func (pl *PodList) Raw(ctx context.Context) (*v1.PodList, error) {
-	return pl.pods.List(ctx, pl.listOptions)
+	return pl.podClient.List(ctx, pl.listOptions)
 }
 
-type PodSelector struct {
-	pods        corev1.PodInterface
+type PodListSelector struct {
+	podClient   corev1.PodInterface
 	listOptions metav1.ListOptions
 }
 
-func (s *PodSelector) ByLabels(labels string) *PodSelector {
-	ps := &PodSelector{
-		pods:        s.pods,
-		listOptions: s.listOptions,
+func (pls *PodListSelector) ByLabels(labels string) *PodListSelector {
+	ps := &PodListSelector{
+		podClient:   pls.podClient,
+		listOptions: pls.listOptions,
 	}
 	ps.listOptions.LabelSelector = labels
 	return ps
 }
 
-func (s *PodSelector) ByFieldSelector(fieldSelector string) *PodSelector {
-	ps := &PodSelector{
-		pods:        s.pods,
-		listOptions: s.listOptions,
+func (pls *PodListSelector) ByFieldSelector(fieldSelector string) *PodListSelector {
+	ps := &PodListSelector{
+		podClient:   pls.podClient,
+		listOptions: pls.listOptions,
 	}
 	ps.listOptions.FieldSelector = fieldSelector
 	return ps
 }
 
-func (s *PodSelector) List() *PodList {
+func (pls *PodListSelector) List() *PodList {
 	return &PodList{
-		pods:        s.pods,
-		listOptions: s.listOptions,
+		podClient:   pls.podClient,
+		listOptions: pls.listOptions,
 	}
 }

--- a/pkg/cluster/pods.go
+++ b/pkg/cluster/pods.go
@@ -3,6 +3,7 @@ package cluster
 import (
 	"context"
 	"fmt"
+
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	corev1 "k8s.io/client-go/kubernetes/typed/core/v1"
@@ -32,30 +33,32 @@ func (pl *PodList) Raw(ctx context.Context) (*v1.PodList, error) {
 	return pl.pods.List(ctx, pl.listOptions)
 }
 
-func (pl *PodList) StatusPhase(ctx context.Context, expected v1.PodPhase) error {
-	list, err := pl.pods.List(ctx, pl.listOptions)
-	if err != nil {
-		return fmt.Errorf("could not list pods for listOptions %s: %s", pl.listOptions.String(), err.Error())
-	}
-
-	for _, pod := range list.Items {
-		if pod.Status.Phase != expected {
-			return fmt.Errorf("pod %s is not in expected lifecycle-pahase. expected; %s; actual: %s", pod.Name, expected, pod.Status.Phase)
-		}
-	}
-
-	return nil
-}
-
 type PodSelector struct {
-	pods corev1.PodInterface
+	pods        corev1.PodInterface
+	listOptions metav1.ListOptions
 }
 
-func (s *PodSelector) ByLabels(labels string) *PodList {
+func (s *PodSelector) ByLabels(labels string) *PodSelector {
+	ps := &PodSelector{
+		pods:        s.pods,
+		listOptions: s.listOptions,
+	}
+	ps.listOptions.LabelSelector = labels
+	return ps
+}
+
+func (s *PodSelector) ByFieldSelector(fieldSelector string) *PodSelector {
+	ps := &PodSelector{
+		pods:        s.pods,
+		listOptions: s.listOptions,
+	}
+	ps.listOptions.FieldSelector = fieldSelector
+	return ps
+}
+
+func (s *PodSelector) List() *PodList {
 	return &PodList{
-		pods: s.pods,
-		listOptions: metav1.ListOptions{
-			LabelSelector: labels,
-		},
+		pods:        s.pods,
+		listOptions: s.listOptions,
 	}
 }

--- a/pkg/cluster/pods.go
+++ b/pkg/cluster/pods.go
@@ -1,0 +1,61 @@
+package cluster
+
+import (
+	"context"
+	"fmt"
+	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	corev1 "k8s.io/client-go/kubernetes/typed/core/v1"
+)
+
+type PodList struct {
+	pods        corev1.PodInterface
+	listOptions metav1.ListOptions
+}
+
+func (pl *PodList) Len(ctx context.Context, expected int) error {
+	list, err := pl.pods.List(ctx, pl.listOptions)
+	if err != nil {
+		return fmt.Errorf("could not list pods for listOptions %s: %w", pl.listOptions.String(), err)
+	}
+
+	itemsLen := len(list.Items)
+	if itemsLen != expected {
+		return fmt.Errorf("did not find expected number of pods: expected: %d; actual: %d", expected, itemsLen)
+	}
+
+	return nil
+}
+
+// Raw queries the kubernetes API and returns the pod list as plain kubernetes API objects.
+func (pl *PodList) Raw(ctx context.Context) (*v1.PodList, error) {
+	return pl.pods.List(ctx, pl.listOptions)
+}
+
+func (pl *PodList) StatusPhase(ctx context.Context, expected v1.PodPhase) error {
+	list, err := pl.pods.List(ctx, pl.listOptions)
+	if err != nil {
+		return fmt.Errorf("could not list pods for listOptions %s: %s", pl.listOptions.String(), err.Error())
+	}
+
+	for _, pod := range list.Items {
+		if pod.Status.Phase != expected {
+			return fmt.Errorf("pod %s is not in expected lifecycle-pahase. expected; %s; actual: %s", pod.Name, expected, pod.Status.Phase)
+		}
+	}
+
+	return nil
+}
+
+type PodSelector struct {
+	pods corev1.PodInterface
+}
+
+func (s *PodSelector) ByLabels(labels string) *PodList {
+	return &PodList{
+		pods: s.pods,
+		listOptions: metav1.ListOptions{
+			LabelSelector: labels,
+		},
+	}
+}

--- a/pkg/cluster/testdata/simpleEchoPod.yaml
+++ b/pkg/cluster/testdata/simpleEchoPod.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: echo-pod
+  labels:
+    app: echo-pod
+spec:
+  containers:
+    - name: alpine
+      image: alpine:latest
+      command:
+        - echo
+      args:
+        - "hello"
+        - "world"

--- a/pkg/wait/strategy.go
+++ b/pkg/wait/strategy.go
@@ -1,1 +1,0 @@
-package wait


### PR DESCRIPTION
This PR resolves #1. It also adds functionality towards #2 by handling pods, logs, and events.

This PR also fixes the go-Module name to `test-clusters/testclusters-go` after moving the project from @ppxl