### PR TITLE
Feature/16 add node health check

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,5 @@
 # testclusters-go Changelog
+
 All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
@@ -8,11 +9,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Added
 
-- add `cluster.*K3dCluster.WriteKubeConfig()` to produce a KUBECONFIG for cluster debugging
+- add `cluster.*K3dCluster.WriteKubeConfig()` to produce a KUBECONFIG for manual cluster debugging
 - [#16] provide feedback on node health for more cluster transparency
 - add convenience constructor `cluster.NewK3dClusterWithOpts()` for further cluster customizing
-  - f. i. log level or custom cluster prefix
+   - f. i. log level or custom cluster prefix
+- [#16] make disk pressure condition configurable
+   - see also the [feature docs](docs/features.md#configure-hard-eviction-string-for-kubelet)
 
 ## Changed
+
 - [#16] clean up cluster containers more robustly
-  - containers may still prevail cleaning if the cluster test will be hard-terminated (f. i. pressing the Debug-Kill 💀 button in IntelliJ IDEA)
+   - containers may still prevail cleaning if the cluster test will be hard-terminated (f. i. pressing the Debug-Kill 💀
+     button in IntelliJ IDEA)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,18 @@
+# testclusters-go Changelog
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+[Unreleased]
+
+## Added
+
+- add `cluster.*K3dCluster.WriteKubeConfig()` to produce a KUBECONFIG for cluster debugging
+- [#16] provide feedback on node health for more cluster transparency
+- add convenience constructor `cluster.NewK3dClusterWithOpts()` for further cluster customizing
+  - f. i. log level or custom cluster prefix
+
+## Changed
+- [#16] clean up cluster containers more robustly
+  - containers may still prevail cleaning if the cluster test will be hard-terminated (f. i. pressing the Debug-Kill 💀 button in IntelliJ IDEA)

--- a/docs/features.md
+++ b/docs/features.md
@@ -1,19 +1,45 @@
 # Features
 
 - Full* cluster functionality at test time
-  - *YMMV for full cluster features
-    - f. e. storage snapshot controllers are not provided by K3s
+   - *YMMV for full cluster features
+      - f. e. storage snapshot controllers are not provided by K3s
 - clean up containers during start-up failure
-  - nobody likes to clean up after other tests ;)
+   - nobody likes to clean up after other tests ;)
 - expose `kubeconfig` to test developer
-  - :note: do you want to debug containers? It does not have to be containers :note:
+   - :note: do you want to debug containers? It does not have to be containers :note:
 - apply kubernetes resources at cluster start-up time
-  - simplify repeated tasks
-- kubectl-like applying of kubernetes YAML resources thanks to the Cloudogu [apply-lib](https://github.com/cloudogu/k8s-apply-lib)
-  - do you want to have resources? Because that's how you get resources
+   - simplify repeated tasks
+- kubectl-like applying of kubernetes YAML resources thanks to the
+  Cloudogu [apply-lib](https://github.com/cloudogu/k8s-apply-lib)
+   - do you want to have resources? Because that's how you get resources
 - Enable external access to cluster pods
-  - Loadbalancer/ingress testing
-  - port forward
+   - Loadbalancer/ingress testing
+   - port forward
 - generate cluster identifiers automatically
 - allow user to choose a custom namespace
 - Test framework agnostic
+- checks node health on cluster start
+
+## Configure hard eviction string for kubelet
+
+Sometimes the developer's computer has very little resources. Often this leads during testing to tainted nodes along
+with an associated node condition.
+
+But developers often know better which resources are needed and when the cluster is to bust. With help of `cluster.Opts` this can be configured
+(currently only for node disk pressure).
+
+```golang
+package yourtestpackage
+
+import (
+  "github.com/test-clusters/testclusters-go/pkg/cluster/health"
+  "github.com/test-clusters/testclusters-go/pkg/cluster"
+  "testing"
+)
+
+func TestYourTestname(t *testing.T) {
+  hardEviction2percent, _ := health.KubeletEvictionFsByPercentage(2) // configure 2 % free hard disk to have no disk pressure condition on the nodes 
+  cl := cluster.NewK3dClusterWithOpts(t, cluster.Opts{NodeConditionEvictionHardArg: hardEviction2percent})
+  ...
+}
+```

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -15,3 +15,44 @@ Remove remaining container networks like this:
 ```bash
 docker network list -f name=k3d-hello --format "{{.Name}}" | xargs docker network rm
 ```
+
+## Workloads do not arrive on node
+
+You may want to check if the node was a failure condition. You can put a local breakpoint in your code and have testclusters-go export the respective KUBECONFIG:
+
+```golang
+func Test_yourTest(t *testing.T) {
+	cl := cluster.NewK3dCluster(t)
+	ctx := context.Background()
+	pathToYouTempKubeConfig := cl.WriteKubeConfig(ctx, t)
+	
+	//put your break point after 
+```
+Events:                                                                                                                             │
+│   Type     Reason                          Age                     From            Message                                          │
+│   ----     ------                          ----                    ----            -------                                          │
+│   Normal   Starting                        8m51s                   kube-proxy                                                       │
+│   Normal   Starting                        8m55s                   kubelet         Starting kubelet.                                │
+│   Warning  InvalidDiskCapacity             8m55s                   kubelet         invalid capacity 0 on image filesystem           │
+│   Normal   NodeHasSufficientMemory         8m55s (x2 over 8m55s)   kubelet         Node k3d-tcg-hello-world-7d476345-server-0 statu │
+│ s is now: NodeHasSufficientMemory                                                                                                   │
+│   Normal   NodeHasNoDiskPressure           8m55s (x2 over 8m55s)   kubelet         Node k3d-tcg-hello-world-7d476345-server-0 statu │
+│ s is now: NodeHasNoDiskPressure                                                                                                     │
+│   Normal   NodeHasSufficientPID            8m55s (x2 over 8m55s)   kubelet         Node k3d-tcg-hello-world-7d476345-server-0 statu │
+│ s is now: NodeHasSufficientPID                                                                                                      │
+│   Normal   NodeReady                       8m55s                   kubelet         Node k3d-tcg-hello-world-7d476345-server-0 statu │
+│ s is now: NodeReady                                                                                                                 │
+│   Normal   NodeAllocatableEnforced         8m55s                   kubelet         Updated Node Allocatable limit across pods       │
+│   Normal   NodePasswordValidationComplete  8m52s                   k3s-supervisor  Deferred node password secret validation complet │
+│ e                                                                                                                                   │
+│   Normal   NodeHasDiskPressure             8m45s                   kubelet         Node k3d-tcg-hello-world-7d476345-server-0 statu │
+│ s is now: NodeHasDiskPressure                                                                                                       │
+│   Warning  EvictionThresholdMet            6m35s (x14 over 8m45s)  kubelet         Attempting to reclaim ephemeral-storage          │
+│   Warning  FreeDiskSpaceFailed             3m55s                   kubelet         Failed to garbage collect required amount of ima │
+│ ges. Attempted to free 164183248076 bytes, but only found 0 bytes eligible to free.                                                 │
+│                                                                                                                                     │
+└─────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┘
+
+### How can node taints like disk pressure be tested?
+
+Create large files that fill up your disk.

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -1,0 +1,17 @@
+# Troubleshooting testclusters-go
+
+## Remove remaining testclusters-go instances
+
+Usually the cluster removes itself once the test exits in a normal way. But killing test processes might leave the started containers up. 
+
+Remove remaining containers like this:
+
+```bash
+docker ps -f name=k3d-hello-world --format "{{.Names}}" | xargs docker rm -f
+```
+
+Remove remaining container networks like this:
+
+```bash
+docker network list -f name=k3d-hello --format "{{.Name}}" | xargs docker network rm
+```

--- a/go.mod
+++ b/go.mod
@@ -36,6 +36,7 @@ require (
 	github.com/docker/go-metrics v0.0.1 // indirect
 	github.com/docker/go-units v0.5.0 // indirect
 	github.com/emicklei/go-restful/v3 v3.11.0 // indirect
+	github.com/evanphx/json-patch v5.6.0+incompatible // indirect
 	github.com/evanphx/json-patch/v5 v5.7.0 // indirect
 	github.com/fsnotify/fsnotify v1.6.0 // indirect
 	github.com/fvbommel/sortorder v1.1.0 // indirect

--- a/pkg/cluster/cluster.go
+++ b/pkg/cluster/cluster.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"strconv"
+	"strings"
 	"testing"
 	"time"
 
@@ -63,9 +64,13 @@ func setupCluster(t *testing.T) *K3dCluster {
 	l.Log().Info("testcluster-go: Creating cluster during  ")
 	var err error
 	ctx := context.Background()
-	cluster, err := CreateK3dCluster(ctx, "hello-world")
+	cluster, err := CreateK3dCluster(ctx, "tcg-"+"hello-world")
 	if err != nil {
+		if strings.Contains(err.Error(), "port is already allocated") {
+			l.Log().Error("Port is already allocated. Was another test-cluster running not properly cleaned up? The clean-up instruction might help.")
+		}
 		t.Errorf("Unexpected error during test setup: %s\n", err)
+		return nil
 	}
 	l.Log().Info("testcluster-go: Cluster was successfully created")
 

--- a/pkg/cluster/cluster.go
+++ b/pkg/cluster/cluster.go
@@ -3,6 +3,10 @@ package cluster
 import (
 	"context"
 	"fmt"
+	"github.com/stretchr/testify/require"
+	"math/rand"
+	"path/filepath"
+	"regexp"
 	"strconv"
 	"strings"
 	"testing"
@@ -29,6 +33,7 @@ import (
 	"github.com/test-clusters/testclusters-go/pkg/naming"
 )
 
+// make this configurable so devs can deploy different clusters or have the need for a custom container naming?
 const appName = "k8s-containers"
 const DefaultNamespace = "default"
 
@@ -39,56 +44,140 @@ const (
 	K3sVersion1_28 = "v1.28.2-k3s1"
 )
 
-type Cluster interface {
+// defaultPrefix contains a marker that will be prepended to testcluster-go containers to distinguish these from other
+// containers (possibly also made with k3d).
+const defaultPrefix = "tc-"
+
+// restrictedContainerNameChars allows only for a prefix lower double-digit number of characters as there will be
+// added further pre- and suffixes:
+//
+//   - "k3d-" by k3d itself
+//   - the defaultPrefix
+//   - 8 alphanumeric characters to identify containers of the same cluster
+//   - the pod name
+const restrictedContainerNameChars = `[a-zA-Z0-9][a-zA-Z0-9_.-]{1..37}`
+
+var restrictedContainerNamePattern = regexp.MustCompile(`^` + restrictedContainerNameChars + `$`)
+
+// Loglevel describes the verbosity of log messages being printed from testcluster-go
+type Loglevel int
+
+const (
+	Error Loglevel = iota
+	Warning
+	Info
+	Debug
+)
+
+type testcluster interface {
+	// Terminate stops all workloads and reclaims spent computational resources.
 	Terminate(ctx context.Context) error
 }
 
+// Opts allows customizing the K3d cluster creation.
+type Opts struct {
+	// ClusterNamePrefix will be used to name the cluster so developers can discover and address a cluster among others.
+	// Defaults to the empty string which is allowed.
+	ClusterNamePrefix string
+	// Loglevel adjusts the verbosity of log outputs produces by K3dCluster. Defaults to Warning.
+	LogLevel Loglevel
+}
+
+// K3dCluster abstracts the cluster management during developer tests.
 type K3dCluster struct {
 	containerRuntime    runtimes.Runtime
 	clusterConfig       *v1alpha5.ClusterConfig
 	kubeConfig          *api.Config
+	clientConfig        *rest.Config
 	ClusterName         string
 	AdminServiceAccount string
-	clientConfig        *rest.Config
+	clientSet           kubernetes.Interface
 }
 
-// NewK3dCluster creates a completely new cluster within the provided container engine. This method is the usual entry point of a test with testclusters-go.
+// NewK3dCluster creates a completely new cluster within the provided container
+// engine and default values. This method is the usual entry point of a test with
+// testclusters-go.
 func NewK3dCluster(t *testing.T) *K3dCluster {
-	cluster := setupCluster(t)
+	defaultOpts := Opts{ClusterNamePrefix: "", LogLevel: Warning}
+	return NewK3dClusterWithOpts(t, defaultOpts)
+}
+
+// NewK3dClusterWithOpts creates like NewK3dCluster a new cluster but with more control over customization.
+func NewK3dClusterWithOpts(t *testing.T, opts Opts) *K3dCluster {
+	cluster := mustSetupCluster(t, opts)
 	registerTearDown(t, cluster)
 
 	return cluster
 }
 
-func setupCluster(t *testing.T) *K3dCluster {
-	l.Log().Info("testcluster-go: Creating cluster during  ")
+func mustSetupCluster(t *testing.T, opts Opts) *K3dCluster {
+	l.Log().Info("testcluster-go: Creating cluster")
 	var err error
 	ctx := context.Background()
-	cluster, err := CreateK3dCluster(ctx, "tcg-"+"hello-world")
+
+	clusterNamePrefix, err := validateClusterNamePrefix(opts.ClusterNamePrefix)
+	if err != nil {
+		errMsg := fmt.Sprintf("testcluster-go: Invalid cluster name prefix found: %s", err.Error())
+		l.Log().Error(errMsg)
+		_ = panicAtStartError(ctx, nil, err)
+	}
+	cluster, err := CreateK3dCluster(ctx, t, clusterNamePrefix)
 	if err != nil {
 		if strings.Contains(err.Error(), "port is already allocated") {
 			l.Log().Error("Port is already allocated. Was another test-cluster running not properly cleaned up? The clean-up instruction might help.")
+			_ = panicAtStartError(ctx, cluster, err)
+			return nil
 		}
-		t.Errorf("Unexpected error during test setup: %s\n", err)
-		return nil
-	}
-	l.Log().Info("testcluster-go: Cluster was successfully created")
 
-	err = cluster.waitForDefaultSACreation(ctx)
-	if err != nil {
-		t.Errorf("failed to wait for default service account: %s", err.Error())
+		t.Errorf("Unexpected error during test setup: %s\n", err)
+		_ = panicAtStartError(ctx, cluster, err)
+		return nil
 	}
 
 	return cluster
 }
 
+func validateClusterNamePrefix(prefix string) (string, error) {
+	generated := generatePseudoPrefix(6)
+	if prefix == "" {
+		return defaultPrefix + generated, nil
+	}
+
+	totalPrefix := defaultPrefix + prefix
+	valid := restrictedContainerNamePattern.MatchString(totalPrefix)
+
+	if valid {
+		return totalPrefix, nil
+	}
+
+	return "", fmt.Errorf("total cluster name prefix '%s' looks invalid (valid pattern: %s)", totalPrefix, restrictedContainerNameChars)
+}
+
+func generatePseudoPrefix(length int) string {
+	const letterBytes = "abcdefghijklmnopqrstuvwxyz0123456789"
+
+	b := make([]byte, length)
+	for i := range b {
+		b[i] = letterBytes[rand.Intn(len(letterBytes))]
+	}
+
+	return string(b)
+}
+
 func registerTearDown(t *testing.T, cluster *K3dCluster) {
+	if cluster == nil || cluster.clusterConfig == nil {
+		t.Errorf("testcluster-go: No cluster or cluster config was found for tear down registration.")
+		return
+	}
+
 	t.Cleanup(func() {
 		l.Log().Debug("testcluster-go: Terminating cluster during test tear down")
+
 		err := cluster.Terminate(context.Background())
 		if err != nil {
 			l.Log().Info("testcluster-go: Cluster was termination failed")
 			t.Errorf("Unexpected error during test tear down: %s\n", err.Error())
+			return
 		}
 		l.Log().Info("testcluster-go: Cluster was successfully terminated")
 	})
@@ -100,11 +189,13 @@ func createClusterConfig(ctx context.Context, clusterName string) (*v1alpha5.Clu
 		return nil, fmt.Errorf("could not find free port for port-forward: %w", err)
 	}
 
+	//TODO fix hardcoding to image reg server. It seems it may be used by different clusters but the port must be configurable.
 	k3sRegistryYaml := `
 my.company.registry":
   endpoint:
   - http://my.company.registry:5000
 `
+	const nodeFilter = "server:*"
 	simpleConfig := v1alpha5.SimpleConfig{
 		TypeMeta: configTypes.TypeMeta{
 			Kind:       "Simple",
@@ -121,6 +212,14 @@ my.company.registry":
 				Wait:    true,
 				Timeout: 60 * time.Second,
 			},
+			K3sOptions: v1alpha5.SimpleConfigOptionsK3s{
+				ExtraArgs: []v1alpha5.K3sArgWithNodeFilters{
+					{ // nodeFilters settings may correspond with the number of servers and agents above
+						// TODO extract with proper naming because here goes some magic
+						Arg:         "--kubelet-arg=eviction-hard=imagefs.available<90%,nodefs.available<90%",
+						NodeFilters: []string{nodeFilter},
+					},
+				}},
 		},
 		// allows unpublished images-under-test to be used in the cluster
 		Registries: v1alpha5.SimpleConfigRegistries{
@@ -169,44 +268,81 @@ my.company.registry":
 	return clusterConfig, nil
 }
 
-// TODO allow the user to overwrite our ClusterConfig with her own
-// func CreateK3dClusterWithConfig() ...
-
 // CreateK3dCluster creates a completely new K8s cluster with an optional clusterNamePrefix.
-func CreateK3dCluster(ctx context.Context, clusterNamePrefix string) (*K3dCluster, error) {
+func CreateK3dCluster(ctx context.Context, t *testing.T, clusterNamePrefix string) (cl *K3dCluster, err error) {
 	containerRuntime := runtimes.SelectedRuntime
 
 	clusterName := naming.MustGenerateK8sName(clusterNamePrefix)
-	cluster := &K3dCluster{
+	cl = &K3dCluster{
 		containerRuntime: containerRuntime,
 		ClusterName:      clusterName,
 	}
 
-	var err error
-	cluster.clusterConfig, err = createClusterConfig(ctx, clusterName)
+	cl.clusterConfig, err = createClusterConfig(ctx, clusterName)
 	if err != nil {
 		return nil, err
 	}
 
-	err = client.ClusterRun(ctx, containerRuntime, cluster.clusterConfig)
+	err = client.ClusterRun(ctx, containerRuntime, cl.clusterConfig)
 	if err != nil {
-		return cluster, handleStartError(ctx, cluster, err)
+		return nil, panicAtStartError(ctx, cl, err)
 	}
 
-	cluster.kubeConfig, err = client.KubeconfigGet(ctx, containerRuntime, &cluster.clusterConfig.Cluster)
+	cl.kubeConfig, err = client.KubeconfigGet(ctx, containerRuntime, &cl.clusterConfig.Cluster)
 	if err != nil {
-		return cluster, handleStartError(ctx, cluster, err)
+		return nil, panicAtStartError(ctx, cl, err)
 	}
-	l.Log().Debugf("testcluster-go: ===== retrieved kube config ====\n%#v\n===== =====", cluster.kubeConfig)
+	l.Log().Debugf("testcluster-go: ===== retrieved kube config ====\n%#v\n===== =====", cl.kubeConfig)
 
-	sa, err := createDefaultRBACForSA(ctx, cluster)
+	err = initializeClientSet(cl)
 	if err != nil {
-		return cluster, handleStartError(ctx, cluster, fmt.Errorf("failed to create default RBAC for SA: %w", err))
+		return nil, panicAtStartError(ctx, cl, fmt.Errorf("failed to initialize clientset: %w", err))
 	}
-	cluster.AdminServiceAccount = sa
 
-	return cluster, nil
+	sa, err := createDefaultRBACForSA(ctx, cl)
+	if err != nil {
+		return cl, panicAtStartError(ctx, cl, fmt.Errorf("failed to create default RBAC for SA: %w", err))
+	}
+	cl.AdminServiceAccount = sa
+
+	l.Log().Info("testcluster-go: Cluster was successfully created")
+
+	err = cl.waitForDefaultSACreation(ctx)
+	if err != nil {
+		return cl, panicAtStartError(ctx, cl, fmt.Errorf("failed to wait for default service account: %w", err))
+	}
+
+	err = cl.checkNodeHealth(ctx, NodeHealthCheckOpts{})
+	if err != nil {
+		return cl, panicAtStartError(ctx, cl, fmt.Errorf("failed to check node health: %w", err))
+	}
+
+	return cl, nil
 }
+
+func initializeClientSet(c *K3dCluster) error {
+	if c.kubeConfig == nil {
+		panic("cluster kubeConfig went unexpectedly nil")
+	}
+	intermediateConfig := clientcmd.NewDefaultClientConfig(*c.kubeConfig, nil)
+	clientConfig, err := intermediateConfig.ClientConfig()
+	if err != nil {
+		return fmt.Errorf("failed to get client config: %w", err)
+	}
+	c.clientConfig = clientConfig
+
+	clientSet, err := kubernetes.NewForConfig(clientConfig)
+	if err != nil {
+		return fmt.Errorf("failed to create clientset: %w", err)
+	}
+
+	c.clientSet = clientSet
+
+	return nil
+}
+
+// TODO allow the user to overwrite our ClusterConfig with her own
+// func CreateK3dClusterWithConfig() ...
 
 func createDefaultRBACForSA(ctx context.Context, c *K3dCluster) (string, error) {
 	const globalGalacticClusterAdminSuffix = "ford-prefect"
@@ -296,10 +432,12 @@ func (c *K3dCluster) waitForDefaultSACreation(ctx context.Context) error {
 
 		_, err = clientset.CoreV1().ServiceAccounts(DefaultNamespace).Get(ctx, "default", metav1.GetOptions{})
 		if err != nil {
-			l.Log().Info("testcluster-go: no default SA found")
+			l.Log().Debug("testcluster-go: no default SA found")
 			return err
 		}
-		l.Log().Info("testcluster-go: found default SA")
+
+		l.Log().Debug("testcluster-go: found default SA")
+		errRetriable = true
 		return nil
 	})
 
@@ -309,16 +447,25 @@ func (c *K3dCluster) waitForDefaultSACreation(ctx context.Context) error {
 	return nil
 }
 
-func handleStartError(ctx context.Context, cluster *K3dCluster, err error) error {
+// panicAtStartError tries to remove the cluster and panics.
+// Testclusters-go is then responsible for resolving the panic.
+// The cluster may be nil.
+func panicAtStartError(ctx context.Context, cluster *K3dCluster, err error) error {
+	if cluster == nil {
+		panic(err.Error())
+		return err
+	}
+
 	err2 := cluster.Terminate(ctx)
 	if err2 != nil {
 		l.Log().Errorf("Another error '%s' occurred while terminating the cluster due to the original error (you may want to clean-up the container landscape): %s", err2.Error(), err)
 	}
 
+	panic(err.Error())
 	return err
 }
 
-// Terminate shuts down the configured cluster.
+// Terminate shuts down the configured k3d cluster.
 func (c *K3dCluster) Terminate(ctx context.Context) error {
 	err := client.ClusterDelete(ctx, c.containerRuntime, &c.clusterConfig.Cluster, k3dTypes.ClusterDeleteOpts{})
 	if err != nil {
@@ -329,23 +476,85 @@ func (c *K3dCluster) Terminate(ctx context.Context) error {
 }
 
 // ClientSet returns a K8s clientset which allows to interoperate with the cluster K8s API.
-func (c *K3dCluster) ClientSet() (*kubernetes.Clientset, error) {
-	if c.kubeConfig == nil {
-		panic("cluster kubeConfig went unexpectedly nil")
-	}
-	intermediateConfig := clientcmd.NewDefaultClientConfig(*c.kubeConfig, nil)
-	clientConfig, err := intermediateConfig.ClientConfig()
-	if err != nil {
-		return nil, err
-	}
-	c.clientConfig = clientConfig
+func (c *K3dCluster) ClientSet() (kubernetes.Interface, error) {
+	return c.clientSet, nil
+}
 
-	clientSet, err := kubernetes.NewForConfig(clientConfig)
+// NodeHealthCheckOpts customizes the way whether and how node health checks are executed.
+type NodeHealthCheckOpts struct {
+	// SkipCheck controls whether a node check should be executed (which is usually a good idea). Defaults to false
+	SkipCheck bool
+}
+
+func (c *K3dCluster) checkNodeHealth(ctx context.Context, opts NodeHealthCheckOpts) error {
+	nodeInfo, err := c.NodeInfo(ctx)
 	if err != nil {
-		return nil, err
+		return err
 	}
 
-	return clientSet, nil
+	if opts.SkipCheck {
+		l.Log().Debugf("testcluster-go: skipping health-check for node %s/%s", nodeInfo.Namespace, nodeInfo.Name)
+		return nil
+	}
+
+	if len(nodeInfo.Spec.Taints) > 0 {
+		return fmt.Errorf("node is not healthy: taint list is not empty: %#v", nodeInfo.Spec.Taints)
+
+	}
+	if len(nodeInfo.Status.Conditions) > 0 {
+		return fmt.Errorf("node is not healthy: condition list is not empty: %#v", nodeInfo.Status.Conditions)
+	}
+
+	l.Log().Debugf("testcluster-go: node %s/%s looks healthy", nodeInfo.Namespace, nodeInfo.Name)
+	return nil
+}
+
+// NodeInfo provides data about a k3d cluster node.
+type NodeInfo struct {
+	*v1.Node
+}
+
+// NodeInfo returns information about current nodes.
+func (c *K3dCluster) NodeInfo(ctx context.Context) (info NodeInfo, err error) {
+	clientset, err := c.ClientSet()
+	if err != nil {
+		return info, fmt.Errorf("could not retrieve node info: %w", err)
+	}
+
+	list, err := clientset.CoreV1().Nodes().List(ctx, metav1.ListOptions{})
+	if err != nil {
+		return info, fmt.Errorf("could not list nodes: %w", err)
+	}
+
+	if len(list.Items) == 0 {
+		return info, fmt.Errorf("could not return node info because no node was found (was it killed in the meantime?)")
+	}
+	if len(list.Items) > 1 {
+		return info, fmt.Errorf("node info does not support more than one node right now")
+	}
+	return NodeInfo{&list.Items[0]}, nil
+}
+
+// WriteKubeConfig writes a Kube Config into the directory. This directory is the
+// same where other Kube Configs may reside. This is useful when a testcluster
+// should be debugged manually.
+func (c *K3dCluster) WriteKubeConfig(ctx context.Context, t *testing.T) string {
+	t.Helper()
+	dir := t.TempDir()
+
+	kubeconf := filepath.Join(dir, "kubeconfig")
+	options := &client.WriteKubeConfigOptions{
+		UpdateExisting:       true,
+		UpdateCurrentContext: true,
+		OverwriteExisting:    true,
+	}
+	pathToKubeConfig, err := client.KubeconfigGetWrite(ctx, c.containerRuntime, &c.clusterConfig.Cluster, kubeconf, options)
+	require.NoError(t, err)
+
+	fmt.Println("writing temporary kubeconfig to", pathToKubeConfig)
+	fmt.Printf("example: KUBECONFIG=%s kubectl get nodes\n", pathToKubeConfig)
+
+	return pathToKubeConfig
 }
 
 func (c *K3dCluster) CtlKube(fieldManager string) (*YamlApplier, error) {
@@ -356,33 +565,30 @@ func (c *K3dCluster) CtlKube(fieldManager string) (*YamlApplier, error) {
 	return yamlApplier, nil
 }
 
-type Lookout struct {
-	t *testing.T
-	c kubernetes.Interface
-}
-
-func (l *Lookout) Pods(namespace string) *PodListSelector {
-	return &PodListSelector{
-		podClient: l.c.CoreV1().Pods(namespace),
-	}
-}
-
-func (l *Lookout) Pod(namespace, name string) *PodSelector {
-	return &PodSelector{
-		podClient:   l.c.CoreV1().Pods(namespace),
-		eventClient: l.c.CoreV1().Events(namespace),
-		name:        name,
-	}
-}
-
-func (c *K3dCluster) Lookout(t *testing.T) *Lookout {
+// MustLookout creates a new Lookout that interacts with the current cluster. It
+// does not return an error but panics with the found error instead.
+func (c *K3dCluster) MustLookout(t *testing.T) *Lookout {
 	clientSet, err := c.ClientSet()
 	if err != nil {
-		t.Errorf("could not build clientSet for cluster: %s", err.Error())
+		errMsg := fmt.Sprintf("mustLookout could not build clientSet for cluster: %s", err.Error())
+		t.Errorf(errMsg)
 	}
 
 	return &Lookout{
 		t: t,
 		c: clientSet,
 	}
+}
+
+// Lookout creates a new Lookout that interacts with the current cluster.
+func (c *K3dCluster) Lookout(t *testing.T) (*Lookout, error) {
+	clientSet, err := c.ClientSet()
+	if err != nil {
+		return nil, fmt.Errorf("lookout could not build clientSet for cluster: %w", err)
+	}
+
+	return &Lookout{
+		t: t,
+		c: clientSet,
+	}, nil
 }

--- a/pkg/cluster/cluster_example_test.go
+++ b/pkg/cluster/cluster_example_test.go
@@ -1,0 +1,61 @@
+package cluster_test
+
+import (
+	"context"
+	_ "embed"
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/test-clusters/testclusters-go/pkg/cluster"
+)
+
+//go:embed testdata/simpleNginxDeployment.yaml
+var simpleNginxDeploymentBytes []byte
+
+//go:embed testdata/simpleEchoPod.yaml
+var simpleEchoPodBytes []byte
+
+func TestIntegration(t *testing.T) {
+	// given
+	cl := cluster.NewK3dClusterWithOpts(t, cluster.Opts{LogLevel: cluster.Debug})
+	ctx := context.Background()
+	cl.WriteKubeConfig(ctx, t)
+
+	kubectl, err := cl.CtlKube(t.Name())
+	require.NoError(t, err)
+
+	// when
+	err = kubectl.ApplyWithFile(ctx, simpleNginxDeploymentBytes)
+	require.NoError(t, err)
+	err = kubectl.ApplyWithFile(ctx, simpleEchoPodBytes)
+	require.NoError(t, err)
+
+	lookout := cl.MustLookout(t)
+
+	pods := lookout.Pods(cluster.DefaultNamespace).ByLabels("app=nginx").ByFieldSelector("status.phase=Running").List()
+	assert.EventuallyWithT(t, func(collectT *assert.CollectT) {
+		err := pods.Len(ctx, 3)
+		if err != nil {
+			collectT.Errorf("%w", err)
+		}
+	}, 60*time.Second, 1*time.Second)
+
+	podList, err := pods.Raw(ctx)
+	require.NoError(t, err)
+
+	events, err := cl.MustLookout(t).Pod(cluster.DefaultNamespace, podList.Items[0].Name).Events(ctx)
+	require.NoError(t, err)
+	fmt.Printf("%#v", events)
+
+	actualLogs, err := cl.MustLookout(t).Pod(cluster.DefaultNamespace, "echo-pod").Logs(ctx)
+	require.NoError(t, err)
+
+	assert.Equal(t, "hello world\n", string(actualLogs))
+
+	// then
+	assert.NoError(t, err)
+}

--- a/pkg/cluster/cluster_example_test.go
+++ b/pkg/cluster/cluster_example_test.go
@@ -21,7 +21,7 @@ var simpleEchoPodBytes []byte
 
 func TestIntegration(t *testing.T) {
 	// given
-	cl := cluster.NewK3dClusterWithOpts(t, cluster.Opts{LogLevel: cluster.Debug})
+	cl := cluster.NewK3dClusterWithOpts(t, cluster.Opts{LogLevel: cluster.Debug, ClusterNamePrefix: "hello-world"})
 	ctx := context.Background()
 	cl.WriteKubeConfig(ctx, t)
 

--- a/pkg/cluster/cluster_test.go
+++ b/pkg/cluster/cluster_test.go
@@ -3,32 +3,6 @@ package cluster
 import (
 	"context"
 	_ "embed"
-	v1 "k8s.io/api/core/v1"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"testing"
-
-	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
-
-	fake "k8s.io/client-go/kubernetes/fake"
 )
 
 var testCtx = context.Background()
-
-func TestK3dCluster_NodeInfo(t *testing.T) {
-	t.Run("should return node info", func(t *testing.T) {
-		// given
-		node := &v1.Node{
-			ObjectMeta: metav1.ObjectMeta{Namespace: "node-namespace", Name: "node-name"},
-		}
-		clientset := fake.NewSimpleClientset(node)
-		sut := K3dCluster{clientSet: clientset}
-
-		// when
-		actual, err := sut.NodeInfo(testCtx)
-
-		// then
-		require.NoError(t, err)
-		assert.Equal(t, NodeInfo{node}, actual)
-	})
-}

--- a/pkg/cluster/command_executor.go
+++ b/pkg/cluster/command_executor.go
@@ -183,9 +183,7 @@ func podHasStatus(pod *corev1.Pod, expectedPodStatus string) error {
 		return fmt.Errorf("unsupported pod status: %s", expectedPodStatus)
 	}
 
-	l.Log().Info("===== =====")
 	l.Log().Infof("expectedPodStatus status %s not fulfilled", expectedPodStatus)
-	l.Log().Info("===== =====")
 	return &TestableRetrierError{Err: fmt.Errorf("expectedPodStatus status %s not fulfilled", expectedPodStatus)}
 }
 

--- a/pkg/cluster/health/checker.go
+++ b/pkg/cluster/health/checker.go
@@ -1,0 +1,38 @@
+package health
+
+import (
+	"fmt"
+	v1 "k8s.io/api/core/v1"
+)
+
+func CheckCondition(nodeInfo *Node) error {
+	for _, node := range nodeInfo.Nodes {
+		for _, condition := range node.Status.Conditions {
+			nodeUsable := true
+			switch condition.Type {
+			case v1.NodeReady:
+				if condition.Status != v1.ConditionTrue {
+					nodeUsable = false
+				}
+			case v1.NodeDiskPressure:
+				fallthrough
+			case v1.NodeMemoryPressure:
+				fallthrough
+			case v1.NodeNetworkUnavailable:
+				fallthrough
+			case v1.NodePIDPressure:
+				if condition.Status != v1.ConditionFalse {
+					nodeUsable = false
+				}
+			default:
+				return fmt.Errorf("unsupported node condition %s", condition.Type)
+			}
+			if !nodeUsable {
+				return fmt.Errorf("node is not healthy: condition list for %s indicates a problem: %#v",
+					node.Name, node.Status.Conditions)
+			}
+		}
+	}
+
+	return nil
+}

--- a/pkg/cluster/health/checker_test.go
+++ b/pkg/cluster/health/checker_test.go
@@ -1,0 +1,75 @@
+package health
+
+import (
+	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"testing"
+)
+
+const (
+	testNodeName = "k3d-tc-123456-server0"
+)
+
+func TestCheckCondition(t *testing.T) {
+	type args struct {
+		nodeInfo *Node
+	}
+	tests := []struct {
+		name    string
+		args    args
+		wantErr bool
+	}{
+		{name: "has no conditions", args: args{nodeInfo: &Node{}}, wantErr: false},
+		{name: "has ready condition",
+			args: args{nodeInfo: &Node{Nodes: []v1.Node{{
+				ObjectMeta: metav1.ObjectMeta{Name: testNodeName},
+				Status:     v1.NodeStatus{Conditions: []v1.NodeCondition{{Type: v1.NodeReady, Status: v1.ConditionTrue}}},
+			}}}},
+			wantErr: false},
+		{name: "has ready condition (complex)",
+			args: args{nodeInfo: &Node{Nodes: []v1.Node{{
+				ObjectMeta: metav1.ObjectMeta{Name: testNodeName},
+				Status: v1.NodeStatus{Conditions: []v1.NodeCondition{
+					{Type: v1.NodeReady, Status: v1.ConditionTrue},
+					{Type: v1.NodeDiskPressure, Status: v1.ConditionFalse},
+				}}}}}},
+			wantErr: false},
+		{name: "has unready condition",
+			args: args{nodeInfo: &Node{Nodes: []v1.Node{{
+				ObjectMeta: metav1.ObjectMeta{Name: testNodeName},
+				Status:     v1.NodeStatus{Conditions: []v1.NodeCondition{{Type: v1.NodeReady, Status: v1.ConditionFalse}}},
+			}}}},
+			wantErr: true},
+		{name: "has disk pressure condition",
+			args: args{nodeInfo: &Node{Nodes: []v1.Node{{
+				ObjectMeta: metav1.ObjectMeta{Name: testNodeName},
+				Status:     v1.NodeStatus{Conditions: []v1.NodeCondition{{Type: v1.NodeDiskPressure, Status: v1.ConditionTrue}}},
+			}}}},
+			wantErr: true},
+		{name: "has memory pressure condition",
+			args: args{nodeInfo: &Node{Nodes: []v1.Node{{
+				ObjectMeta: metav1.ObjectMeta{Name: testNodeName},
+				Status:     v1.NodeStatus{Conditions: []v1.NodeCondition{{Type: v1.NodeMemoryPressure, Status: v1.ConditionTrue}}},
+			}}}},
+			wantErr: true},
+		{name: "has network unavailable condition",
+			args: args{nodeInfo: &Node{Nodes: []v1.Node{{
+				ObjectMeta: metav1.ObjectMeta{Name: testNodeName},
+				Status:     v1.NodeStatus{Conditions: []v1.NodeCondition{{Type: v1.NodeNetworkUnavailable, Status: v1.ConditionTrue}}},
+			}}}},
+			wantErr: true},
+		{name: "has PID pressure condition",
+			args: args{nodeInfo: &Node{Nodes: []v1.Node{{
+				ObjectMeta: metav1.ObjectMeta{Name: testNodeName},
+				Status:     v1.NodeStatus{Conditions: []v1.NodeCondition{{Type: v1.NodePIDPressure, Status: v1.ConditionTrue}}},
+			}}}},
+			wantErr: true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if err := CheckCondition(tt.args.nodeInfo); (err != nil) != tt.wantErr {
+				t.Errorf("CheckTaint() error = %v, wantErr %v", err, tt.wantErr)
+			}
+		})
+	}
+}

--- a/pkg/cluster/health/nodeinfo.go
+++ b/pkg/cluster/health/nodeinfo.go
@@ -1,0 +1,61 @@
+package health
+
+import (
+	"context"
+	"fmt"
+	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes"
+	"strings"
+)
+
+// Node provides data about a k3d cluster node.
+type Node struct {
+	Nodes []v1.Node
+}
+
+// String returns a printable list of all nodes and their namespace.
+func (info *Node) String() string {
+	sb := strings.Builder{}
+	for i, node := range info.Nodes {
+		sb.WriteString("node: ")
+		sb.WriteString(node.Name)
+		if i < len(info.Nodes)-1 {
+			sb.WriteString(", ")
+		}
+	}
+
+	return sb.String()
+}
+
+// FetchNodeInfo returns information about current nodes.
+func FetchNodeInfo(ctx context.Context, clientset kubernetes.Interface) (info *Node, err error) {
+	if clientset == nil {
+		return info, fmt.Errorf("clientset must not be nil")
+	}
+	if err != nil {
+		return info, fmt.Errorf("could not retrieve node info: %w", err)
+	}
+
+	list, err := clientset.CoreV1().Nodes().List(ctx, metav1.ListOptions{})
+	if err != nil {
+		return info, fmt.Errorf("could not list nodes: %w", err)
+	}
+
+	if len(list.Items) == 0 {
+		return info, fmt.Errorf("could not return node info because no node was found (was it killed in the meantime?)")
+	}
+
+	return &Node{list.Items}, nil
+}
+
+// KubeletEvictionFsByPercentage takes a percentage integer from 0 to 100 and
+// returns a matching kubelet hard-eviction argument. A percentage of 10 means
+// that with 10 % free space, the cluster will start to taint the nodes,
+// effectively blocking workloads to be scheduled.
+func KubeletEvictionFsByPercentage(percentage int) (string, error) {
+	if percentage < 0 || percentage > 100 {
+		return "", fmt.Errorf("percentage must be in rage of 0 and 100")
+	}
+	return fmt.Sprintf("imagefs.available<%d%%,nodefs.available<%d%%", percentage, percentage), nil
+}

--- a/pkg/cluster/health/nodeinfo_test.go
+++ b/pkg/cluster/health/nodeinfo_test.go
@@ -1,0 +1,66 @@
+package health
+
+import (
+	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"testing"
+)
+
+func TestNode_String(t *testing.T) {
+	type fields struct {
+		Nodes []v1.Node
+	}
+	tests := []struct {
+		name   string
+		fields fields
+		want   string
+	}{
+		{name: "no nodes", fields: fields{Nodes: []v1.Node{}}, want: ""},
+		{name: "no nodes", fields: fields{Nodes: nil}, want: ""},
+		{name: "1 node", fields: fields{Nodes: []v1.Node{{ObjectMeta: metav1.ObjectMeta{Name: "hello-world"}}}}, want: "node: hello-world"},
+		{name: "2 node", fields: fields{Nodes: []v1.Node{
+			{ObjectMeta: metav1.ObjectMeta{Name: "hello"}},
+			{ObjectMeta: metav1.ObjectMeta{Name: "world"}},
+		}}, want: "node: hello, node: world"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			info := &Node{
+				Nodes: tt.fields.Nodes,
+			}
+			if got := info.String(); got != tt.want {
+				t.Errorf("String() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestKubeletEvictionFsByPercentage(t *testing.T) {
+	type args struct {
+		percentage int
+	}
+	tests := []struct {
+		name    string
+		args    args
+		want    string
+		wantErr bool
+	}{
+		{"-1", args{percentage: -1}, "", true},
+		{"0", args{percentage: 0}, "imagefs.available<0%,nodefs.available<0%", false},
+		{"50", args{percentage: 50}, "imagefs.available<50%,nodefs.available<50%", false},
+		{"100", args{percentage: 100}, "imagefs.available<100%,nodefs.available<100%", false},
+		{"101", args{percentage: 101}, "", true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := KubeletEvictionFsByPercentage(tt.args.percentage)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("KubeletEvictionFsByPercentage() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if got != tt.want {
+				t.Errorf("KubeletEvictionFsByPercentage() got = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/pkg/cluster/lookout.go
+++ b/pkg/cluster/lookout.go
@@ -1,0 +1,28 @@
+package cluster
+
+import (
+	"k8s.io/client-go/kubernetes"
+	"testing"
+)
+
+// Lookout provides convenience functionalities for cluster resources.
+type Lookout struct {
+	t *testing.T
+	c kubernetes.Interface
+}
+
+// Pods returns a PodListSelector to address multiple pods.
+func (l *Lookout) Pods(namespace string) *PodListSelector {
+	return &PodListSelector{
+		podClient: l.c.CoreV1().Pods(namespace),
+	}
+}
+
+// Pod returns a single PodSelector to address a single pod.
+func (l *Lookout) Pod(namespace, name string) *PodSelector {
+	return &PodSelector{
+		podClient:   l.c.CoreV1().Pods(namespace),
+		eventClient: l.c.CoreV1().Events(namespace),
+		name:        name,
+	}
+}

--- a/pkg/naming/naming.go
+++ b/pkg/naming/naming.go
@@ -9,6 +9,7 @@ import (
 	"k8s.io/apimachinery/pkg/util/validation"
 )
 
+// MustGenerateK8sName returns a random alphanumeric name that is RFC 1123 compatible (DNS)
 func MustGenerateK8sName(prefix string) string {
 	if prefix != "" {
 		rfcCheckErrs := validation.IsDNS1123Label(prefix)


### PR DESCRIPTION
This PR resolves #16 by checking the node's health and properly tearing down the cluster if the node is unhealthy.

Further more this PR enables the circumstances under which a node can be tainted. Works on my machine™ but I had disk pressure taint to begin with so it seems to work.